### PR TITLE
fix bit reference compile error

### DIFF
--- a/vapid/soa.h
+++ b/vapid/soa.h
@@ -40,7 +40,9 @@ namespace vapid {
 
         void reset(size_t perm_size) {
             element_visited.resize(perm_size);
-            for (auto& b : element_visited) {
+
+            // gcc chokes on `for (auto& b : element_visited)`
+            for (std::vector<bool>::reference b : element_visited) {
                 b = false;
             }
 


### PR DESCRIPTION
Fix error when compiling with gcc

```
error: cannot bind non-const lvalue reference of type 'std::_Bit_reference&' to an rvalue of type 'std::_Bit_iterator::reference' {aka 'std::_Bit_reference'}
   43 |             for (auto& b : element_visited) {
```