### PR TITLE
rework sort order reference

### DIFF
--- a/vapid/soa.h
+++ b/vapid/soa.h
@@ -156,7 +156,6 @@ namespace vapid {
         template <typename... Xs>
         void insert(Xs... xs) {
             insert_impl(std::index_sequence_for<Ts...>{}, std::forward_as_tuple(xs...));
-            sort_order_reference_.push_back(size() - 1);
         }
 
         auto operator[](size_t idx) const {
@@ -277,6 +276,7 @@ namespace vapid {
         }
 
         void reset_sort_reference() {
+            sort_order_reference_.resize(size());
             for (size_t i = 0; i < size(); ++i) {
                 sort_order_reference_[i] = i;
             }


### PR DESCRIPTION
The sort order reference was previously maintained during the insert() call, but this could go out of sync if the user directly inserts into each underlying column manually. Now the maintenance is done inside the reset_sort_order_reference() call. 