### PR TITLE
Performance fix: avoid unnecessary vector copy

### DIFF
--- a/vapid/soa.h
+++ b/vapid/soa.h
@@ -194,7 +194,7 @@ namespace vapid {
 
             auto& col = get_column<col_idx>();
 
-            auto comparator_wrapper = [=](size_t a, size_t b) {
+            auto comparator_wrapper = [&](size_t a, size_t b) {
                 return comparator(col[a], col[b]);
             };
 


### PR DESCRIPTION
Capturing by values does a copy of the whole column vector.

### benchmark **before** the change:

```
-------------------------------------------------------------------------------------------
Benchmark                                                 Time             CPU   Iterations
-------------------------------------------------------------------------------------------
BM_SoaSortBySensorId_ArrayData                    247415702 ns    247412636 ns            3
BM_SoaSortBySensorId_ArrayData_NoDoubleBuffering  257742246 ns    257738720 ns            3
BM_VecSortBySensorId_ArrayData                      7545220 ns      7545168 ns           90
BM_SoaSortBySensorId_StringData                   245846669 ns    245844770 ns            3
BM_VecSortBySensorId_StringData                     6431223 ns      6431201 ns          111
BM_SoaSumTimestamps_ArrayData                         55087 ns        55086 ns        12611
BM_VecSumTimestamps_ArrayData                         56923 ns        56922 ns        12366
```

### benchmark **after** the change:

```
-------------------------------------------------------------------------------------------
Benchmark                                                 Time             CPU   Iterations
-------------------------------------------------------------------------------------------
BM_SoaSortBySensorId_ArrayData                      6767194 ns      6767019 ns          103
BM_SoaSortBySensorId_ArrayData_NoDoubleBuffering   11421012 ns     11420679 ns           61
BM_VecSortBySensorId_ArrayData                      7497347 ns      7497166 ns           92
BM_SoaSortBySensorId_StringData                     5566779 ns      5566589 ns          132
BM_VecSortBySensorId_StringData                     6373367 ns      6373051 ns          111
BM_SoaSumTimestamps_ArrayData                         54794 ns        54793 ns        12676
BM_VecSumTimestamps_ArrayData                         56574 ns        56572 ns        12399
```

